### PR TITLE
Fix saving ID retrieval in NewEditTransactionActivity

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -656,7 +656,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     mSavingId = intent.getLongExtra(SAVING_ID, 0L);
                     long savingMoney = 0L;
                     long savingProgress = 0L;
-                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, getItemId());
+                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
                     String[] projection = new String[] {
                             Contract.Saving.END_MONEY,
                             Contract.Saving.WALLET_ID,


### PR DESCRIPTION
Issue - https://github.com/nitr-himanshu/MWPlus/issues/5
- Updated the URI construction to use mSavingId instead of getItemId for accurate data fetching from the content provider.