### PR TITLE
Add transaction cloning feature in NewEditTransactionActivity

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -803,6 +803,30 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                 mCategoryEditText.setVisibility(View.GONE);
                 break;
         }
+        // Check if we're cloning a transaction and override the default values
+        Intent intent = getIntent();
+        if (savedInstanceState == null && intent.hasExtra("clone_money")) {
+            // Override values with cloned data
+            money = intent.getLongExtra("clone_money", money);
+            if (intent.hasExtra("clone_category")) {
+                category = intent.getParcelableExtra("clone_category");
+            }
+            if (intent.hasExtra("clone_wallet")) {
+                wallet = intent.getParcelableExtra("clone_wallet");
+            }
+            if (intent.hasExtra("clone_event")) {
+                event = intent.getParcelableExtra("clone_event");
+            }
+            if (intent.hasExtra("clone_place")) {
+                place = intent.getParcelableExtra("clone_place");
+            }
+            if (intent.hasExtra("clone_people")) {
+                people = (Person[]) intent.getParcelableArrayExtra("clone_people");
+            }
+            // Don't clone attachments - let user add new ones if needed
+            attachments = null;
+        }
+        
         // now we can create pickers with default values or existing item parameters
         // and update all the views according to the data
         FragmentManager fragmentManager = getSupportFragmentManager();
@@ -817,6 +841,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         // check if the intent contains some predefined value for fields
         if (savedInstanceState == null) {
             fillFieldsFromIntent(getIntent());
+            // Check if this is a cloned transaction and restore the cloned data
+            restoreClonedData(getIntent());
         }
     }
 
@@ -839,6 +865,28 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                 }
             }
         }
+    }
+
+    private void restoreClonedData(Intent intent) {
+        // Check if this intent contains cloned transaction data
+        if (!intent.hasExtra("clone_money")) {
+            return; // Not a cloned transaction
+        }
+        
+        // Restore text fields and checkboxes
+        // (Pickers are already initialized with cloned data in onViewCreated)
+        String description = intent.getStringExtra("clone_description");
+        if (description != null) {
+            mDescriptionEditText.setText(description);
+        }
+        
+        String note = intent.getStringExtra("clone_note");
+        if (note != null) {
+            mNoteEditText.setText(note);
+        }
+        
+        mConfirmedCheckBox.setChecked(intent.getBooleanExtra("clone_confirmed", false));
+        mCountInTotalCheckBox.setChecked(intent.getBooleanExtra("clone_count_in_total", true));
     }
 
     @Override

--- a/app/src/main/res/menu/menu_clone_edit_delete_transaction.xml
+++ b/app/src/main/res/menu/menu_clone_edit_delete_transaction.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_clone_transaction"
+        android:icon="@drawable/ic_content_paste_black_24dp"
+        android:title="@string/menu_action_clone_transaction"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_edit_item"
+        android:icon="@drawable/ic_mode_edit_black_24dp"
+        android:title="@string/menu_action_edit_item"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_item"
+        android:icon="@drawable/ic_delete_black_24dp"
+        android:title="@string/menu_action_delete_item"
+        app:showAsAction="ifRoom" />
+
+</menu>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="title_fragment_item_person">"Person"</string>
 
     <string name="menu_action_attach_file">"Attach file"</string>
+    <string name="menu_action_clone_transaction">"Clone"</string>
     <string name="menu_action_save_changes">"Save changes"</string>
     <string name="menu_refresh_currency_rate">"Refresh currency rate"</string>
     <string name="menu_advanced_settings">"Advanced settings"</string>


### PR DESCRIPTION
- Implemented functionality to clone existing transactions, allowing users to duplicate transaction data including money, description, note, and associated entities (category, wallet, event, place, and people).
- Updated TransactionItemFragment to include a new menu option for cloning transactions.
- Created a new menu resource for clone, edit, and delete actions.
- Enhanced string resources to support the new clone action.
https://github.com/nitr-himanshu/MWPlus/issues/9