### PR TITLE
Storage permission issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
         debug {
             applicationIdSuffix ".dev"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,10 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" 
+        android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />


### PR DESCRIPTION
- Added signing configuration for release builds in build.gradle.
- Updated AndroidManifest.xml to set maxSdkVersion for WRITE_EXTERNAL_STORAGE and added MANAGE_EXTERNAL_STORAGE permission.
- Refactored DiskBackendService to handle storage permissions for Android 11 and above, implementing logic to request MANAGE_EXTERNAL_STORAGE.
- Enhanced AutoBackupBroadcastReceiver to check backend service permissions before executing auto-backup, ensuring required permissions are granted.

https://github.com/nitr-himanshu/MWPlus/issues/17